### PR TITLE
WIP: Synthesise with provided GST weights

### DIFF
--- a/espnet2/bin/tts_inference.py
+++ b/espnet2/bin/tts_inference.py
@@ -153,6 +153,7 @@ class Text2Speech:
         spembs: Union[torch.Tensor, np.ndarray] = None,
         sids: Union[torch.Tensor, np.ndarray] = None,
         lids: Union[torch.Tensor, np.ndarray] = None,
+        gst_weights: Union[torch.Tensor, np.ndarray] = None,
         decode_conf: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, torch.Tensor]:
         """Run text-to-speech."""
@@ -182,6 +183,8 @@ class Text2Speech:
             batch.update(sids=sids)
         if lids is not None:
             batch.update(lids=lids)
+        if gst_weights is not None:
+            batch.update(gst_weights=gst_weights)
         batch = to_device(batch, self.device)
 
         # overwrite the decode configs if provided

--- a/espnet2/tasks/tts.py
+++ b/espnet2/tasks/tts.py
@@ -271,6 +271,7 @@ class TTSTask(AbsTask):
                 "energy",
                 "sids",
                 "lids",
+                "gst_weights",
             )
         return retval
 

--- a/espnet2/tts/fastspeech2/fastspeech2.py
+++ b/espnet2/tts/fastspeech2/fastspeech2.py
@@ -628,13 +628,9 @@ class FastSpeech2(AbsTTS):
         hs, _ = self.encoder(xs, x_masks)  # (B, T_text, adim)
 
         # integrate with GST
-        # TODO: add option to take provided style_embs/weights
         if self.use_gst:
             style_embs = self.gst(ys, gst_weights)
             hs = hs + style_embs.unsqueeze(1)
-            # FIXME: remove -- just checking modification to mha
-            if gst_weights is not None:
-                assert self.gst.stl.mha.attn == gst_weights
             gst_weights_outs = self.gst.stl.mha.attn  # set during forward pass
         else:
             gst_weights_outs = None
@@ -730,6 +726,7 @@ class FastSpeech2(AbsTTS):
             spembs (Optional[Tensor): Speaker embedding vector (spk_embed_dim,).
             sids (Optional[Tensor]): Speaker ID (1,).
             lids (Optional[Tensor]): Language ID (1,).
+            gst_weights (Optional[Tensor]): GST (gst_heads, gst_tokens).
             pitch (Optional[Tensor]): Groundtruth of token-avg pitch (T_text + 1, 1).
             energy (Optional[Tensor]): Groundtruth of token-avg energy (T_text + 1, 1).
             alpha (float): Alpha to control the speed.

--- a/espnet2/tts/fastspeech2/fastspeech2.py
+++ b/espnet2/tts/fastspeech2/fastspeech2.py
@@ -494,6 +494,7 @@ class FastSpeech2(AbsTTS):
         spembs: Optional[torch.Tensor] = None,
         sids: Optional[torch.Tensor] = None,
         lids: Optional[torch.Tensor] = None,
+        gst_weights: Optional[torch.Tensor] = None,
         joint_training: bool = False,
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor], torch.Tensor]:
         """Calculate forward propagation.
@@ -512,6 +513,7 @@ class FastSpeech2(AbsTTS):
             spembs (Optional[Tensor]): Batch of speaker embeddings (B, spk_embed_dim).
             sids (Optional[Tensor]): Batch of speaker IDs (B, 1).
             lids (Optional[Tensor]): Batch of language IDs (B, 1).
+            gst_weights (Optional[Tensor]): Batch of GST weights (B, gst_heads, gst_tokens).
             joint_training (bool): Whether to perform joint training with vocoder.
 
         Returns:
@@ -538,7 +540,7 @@ class FastSpeech2(AbsTTS):
         olens = feats_lengths
 
         # forward propagation
-        before_outs, after_outs, d_outs, p_outs, e_outs, gst_weights = self._forward(
+        before_outs, after_outs, d_outs, p_outs, e_outs, gst_weights_outs = self._forward(
             xs,
             ilens,
             ys,
@@ -549,6 +551,7 @@ class FastSpeech2(AbsTTS):
             spembs=spembs,
             sids=sids,
             lids=lids,
+            gst_weights=gst_weights,
             is_inference=False,
         )
 
@@ -616,6 +619,7 @@ class FastSpeech2(AbsTTS):
         spembs: Optional[torch.Tensor] = None,
         sids: Optional[torch.Tensor] = None,
         lids: Optional[torch.Tensor] = None,
+        gst_weights: Optional[torch.Tensor] = None,
         is_inference: bool = False,
         alpha: float = 1.0,
     ) -> Sequence[torch.Tensor]:
@@ -626,11 +630,14 @@ class FastSpeech2(AbsTTS):
         # integrate with GST
         # TODO: add option to take provided style_embs/weights
         if self.use_gst:
-            style_embs = self.gst(ys)
+            style_embs = self.gst(ys, gst_weights)
             hs = hs + style_embs.unsqueeze(1)
-            gst_weights = self.gst.stl.mha.attn  # set during forward pass
+            # FIXME: remove -- just checking modification to mha
+            if gst_weights is not None:
+                assert self.gst.stl.mha.attn == gst_weights
+            gst_weights_outs = self.gst.stl.mha.attn  # set during forward pass
         else:
-            gst_weights = None
+            gst_weights_outs = None
 
         # integrate with SID and LID embeddings
         if self.spks is not None:
@@ -698,7 +705,7 @@ class FastSpeech2(AbsTTS):
                 before_outs.transpose(1, 2)
             ).transpose(1, 2)
 
-        return before_outs, after_outs, d_outs, p_outs, e_outs, gst_weights
+        return before_outs, after_outs, d_outs, p_outs, e_outs, gst_weights_outs
 
     def inference(
         self,
@@ -708,6 +715,7 @@ class FastSpeech2(AbsTTS):
         spembs: torch.Tensor = None,
         sids: Optional[torch.Tensor] = None,
         lids: Optional[torch.Tensor] = None,
+        gst_weights: Optional[torch.Tensor] = None,
         pitch: Optional[torch.Tensor] = None,
         energy: Optional[torch.Tensor] = None,
         alpha: float = 1.0,
@@ -753,7 +761,7 @@ class FastSpeech2(AbsTTS):
         if use_teacher_forcing:
             # use groundtruth of duration, pitch, and energy
             ds, ps, es = d.unsqueeze(0), p.unsqueeze(0), e.unsqueeze(0)
-            _, outs, d_outs, p_outs, e_outs, gst_weights = self._forward(
+            _, outs, d_outs, p_outs, e_outs, gst_weights_outs = self._forward(
                 xs,
                 ilens,
                 ys,
@@ -763,28 +771,30 @@ class FastSpeech2(AbsTTS):
                 spembs=spembs,
                 sids=sids,
                 lids=lids,
+                gst_weights=gst_weights,
             )  # (1, T_feats, odim)
         else:
-            _, outs, d_outs, p_outs, e_outs, gst_weights = self._forward(
+            _, outs, d_outs, p_outs, e_outs, gst_weights_outs = self._forward(
                 xs,
                 ilens,
                 ys,
                 spembs=spembs,
                 sids=sids,
                 lids=lids,
+                gst_weights=gst_weights,
                 is_inference=True,
                 alpha=alpha,
             )  # (1, T_feats, odim)
 
-        if gst_weights is not None:
-            gst_weights = gst_weights[0]
+        if gst_weights_outs is not None:
+            gst_weights_outs = gst_weights_outs[0]
 
         return dict(
             feat_gen=outs[0],
             duration=d_outs[0],
             pitch=p_outs[0],
             energy=e_outs[0],
-            gst_weights=gst_weights,
+            gst_weights=gst_weights_outs,
         )
 
     def _integrate_with_spk_embed(

--- a/espnet2/tts/gst/style_encoder.py
+++ b/espnet2/tts/gst/style_encoder.py
@@ -3,7 +3,8 @@
 
 """Style encoder of GST-Tacotron."""
 
-from typing import Sequence
+import math
+from typing import Optional, Sequence
 
 import torch
 from typeguard import check_argument_types


### PR DESCRIPTION
Adding a path to pass pre-specified GST weights for TTS synthesis, rather than deriving them from reference audio.

## Usage

Right now I think this should work like this:

```bash
tts.sh \
  --stage 7 \  # synthesis step
  --inference-args "--data_paths_and_name_and_type /path/to/gst_weights.scp,gst_weights,npy" \
  ${other_tts_args}
```

`tts.sh` is `egs2/TEMPLATE/tts1/tts.sh`, which I think is the basis for all `run.sh` in `egs2` TTS experiments. The `--data_paths_and_name_and_type` arg should just be passed straight through to `espnet2.bin.tts_inference.py` and handled as an extra input, no explicit declaration necessary (only `speech` seems to be a special name here checked in other parts of the code).

The file `gst_weights.scp` should link utterance IDs to NumPy arrays on disk with GST weights of shape `(1, gst_heads, gst_tokens)` (i.e. `(1, 4, 10)` in our current experiments), like so:

```txt
alba_clear_1_0394 /path/to/dumped/gst_weights/clear.npy
alba_plain_1_0394 /path/to/dumped/gst_weights/plain.npy
alba_clear_1_0395 /path/to/dumped/gst_weights/alba_plain_1_0413.npy
```

For example, `clear.npy` could be some average set of weights over all clear utterances, or another arbitrary set we provide, or we could mix and match weights from other utterances. The utterance IDs should match whatever is in existing `text`, `wav.scp` etc. data files for our test utterances.

## Notes

- For now, I think this will still dump the GST weights that we load in back out during synthesis, but probably in a different location and with names matching the input utterance ID, so it should be non-destructive. Passing `--write_collected_feats false` prevents this.
- Input reference audio is still expected, as in the default inference recipe, but should be ignored as we pass through the `StyleTokenLayer` in `espnet2.tts.gst.style_encoder.py`. Unfortunately we still run the `ReferenceEncoder` itself.
- An alternative input representation could be CSV files with lines like `utt_id 0.1,0.03,...,-0.2`, with `gst_heads * gst_tokens` fields which we then reshape. Might be easier for quick manual edits than modifying NumPy arrays.